### PR TITLE
Add deployment scripts

### DIFF
--- a/deploy/Chart.yaml
+++ b/deploy/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+version: "0.1.0"
+name: semaphore-airdrop-relayer
+appVersion: "0.0.1"
+description: "A server that relays proofs to Semaphore Airdrop contracts."
+home: https://github.com/worldcoin/semaphore-airdrop-relayer
+sources:
+  - https://github.com/worldcoin/semaphore-airdrop-relayer
+keywords:
+  - worldcoin
+  - semaphore
+  - relayer
+maintainers:
+  - name: Miguel Piedrafita
+    email: miguel.piedrafita@worldcoin.org

--- a/deploy/templates/NOTES.txt
+++ b/deploy/templates/NOTES.txt
@@ -1,0 +1,5 @@
+1. Get the application URL by running these commands:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mychart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/deploy/templates/_helpers.tpl
+++ b/deploy/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mychart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mychart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mychart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mychart.labels" -}}
+helm.sh/chart: {{ include "mychart.chart" . }}
+{{ include "mychart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ .Values.labels.component | default .Chart.Name | quote }}
+app.kubernetes.io/part-of: {{ .Values.labels.partOf | quote }}
+{{- if .Values.labels.createdBy }}
+app.kubernetes.io/created-by: {{ .Values.labels.createdBy | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mychart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mychart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mychart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mychart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mychart.fullname" . }}
+  annotations:
+    kube-score/ignore: pod-probes # TODO
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "mychart.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "mychart.fullname" . }}
+        {{- include "mychart.labels" . | nindent 8 }}
+    spec:
+      {{ with .Values.image.pullSecret -}}
+      imagePullSecrets:
+        - name: {{ . }}
+      {{ end -}}
+      nodeSelector:
+        beta.kubernetes.io/arch: {{ .Values.image.arch }}
+      containers:
+        - name: app
+          image: "{{ .Values.image.image }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion)}}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+          ports:
+            - name: api
+              containerPort: 3000
+              protocol: TCP
+          env:
+            {{- range $name, $item := .Values.env }}
+            - name: {{ $name }}
+              {{- if kindIs "map" $item }}
+              {{- $item | toYaml | nindent 14 }}
+              {{- else }}
+              value: {{ $item | quote }}
+              {{- end }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+              drop:
+                - all
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            runAsUser: 10001
+            runAsGroup: 10001

--- a/deploy/templates/ingress.yaml
+++ b/deploy/templates/ingress.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.canary.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "mychart.fullname" . }}
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    ingress.kubernetes.io/protocol: http
+    traefik.frontend.rule.type: PathPrefix
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "{{ include "mychart.fullname" . }}"
+                port:
+                  name: api
+{{- end }}

--- a/deploy/templates/network-policy.yaml
+++ b/deploy/templates/network-policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: { { include "mychart.fullname" . } }
+  labels: { { - include "mychart.labels" . | nindent 4 } }
+spec:
+  podSelector:
+    matchLabels:
+      app: { { include "mychart.fullname" . } }
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: api
+          protocol: TCP
+      from: { { - toYaml .Values.ingress.api | nindent 6 } }
+  egress:
+    # TODO: Limit egress traffic to ethereum-rpc.
+    # Currently not possible to specify by domain name.
+    - {} # Allow all

--- a/deploy/templates/service.yaml
+++ b/deploy/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.canary.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mychart.fullname" . }}
+  labels:
+    {{- include "mychart.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "mychart.fullname" . }}
+  ports:
+    - name: api
+      protocol: TCP
+      port: 80
+      targetPort: api
+{{- end }}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -1,0 +1,36 @@
+image:
+  image: "ghcr.io/worldcoin/semaphore-airdrop-relayer"
+  tag: # Defaults to `v` + appVersion
+  arch: amd64 # Either amd64 or arm64
+  pullSecret:
+
+labels:
+  component: # Defaults to name
+  partOf: semaphore-airdrop
+  createdBy:
+
+environment: prod
+replicas: 1
+region: "us-east-1"
+
+canary:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 0.1
+    memory: 128Mi
+  limits:
+    cpu: 16.0
+    memory: 4Gi
+
+# Env values can be strings (to be prefixed with `value:`) or objects
+env:
+  NETWORK: "rinkeby"
+
+# Spec ingress policy for the `api` and `metrics` port.
+# Values are a list of NetworkPolicyPeer v1 objects, empty means allow all.
+ingress:
+  host: "semaphore-airdrop.demo.worldcoin.dev"
+  api:
+  metrics:


### PR DESCRIPTION
My understanding of this repository was it served as a template for users setting up their own external airdrop (since the contract only supports one token at a time). Should the relayer be updated to work with @lucasege's multi-token airdrop implementation (where it'd get used by us, and makes sense to deploy), or is my understanding correct (and if so, does it really make sense for us to maintain a hosted version?).

Regardless of the above, leaving some comments on the configuration params I'm not sure about.